### PR TITLE
Remove collect udev component

### DIFF
--- a/bin_files
+++ b/bin_files
@@ -130,7 +130,6 @@
 /usr/bin/modprobe
 /usr/lib/udev/ata_id
 /usr/lib/udev/cdrom_id
-/usr/lib/udev/collect
 /usr/lib/udev/hid2hci
 /usr/lib/udev/kpartx_id
 /usr/lib/udev/libinput-device-group


### PR DESCRIPTION
Systemd 241 removed collect udev component as it is neither used nor
maintained, according to systemd's release notes.