### PR TITLE
initramfs: drop binary from systemd

### DIFF
--- a/bin_files
+++ b/bin_files
@@ -84,7 +84,6 @@
 /usr/lib/systemd/systemd-fsck
 /usr/lib/systemd/systemd-hibernate-resume
 /usr/lib/systemd/systemd-hostnamed
-/usr/lib/systemd/systemd-initctl
 /usr/lib/systemd/systemd-journald
 /usr/lib/systemd/systemd-localed
 /usr/lib/systemd/systemd-logind


### PR DESCRIPTION
Previously systemd-initctl had no function because Clear Linux OS
compiles systemd without sysvinit support anyway. Upstream now no
longer installs the file if that happens start with systemd 246.

Signed-off-by: Mark D Horn <mark.d.horn@intel.com>