### PR TITLE
glibc 2.34 merged libnss

### DIFF
--- a/bin_files
+++ b/bin_files
@@ -81,7 +81,6 @@
 /usr/bin/xfs_metadump
 /usr/bin/xfs_repair
 /usr/lib64/libnss_altfiles.so.*
-/usr/lib64/libnss_files-*.so
 /usr/lib64/libnss_files.so.*
 /usr/lib64/multipath/*
 /usr/lib/systemd/libsystemd-shared-*.so


### PR DESCRIPTION
The NSS files and dns plugins are now builtin to libc as of 2.34
https://sourceware.org/glibc/wiki/Release/2.34
